### PR TITLE
Corrige a url do fluig em alguns serviços

### DIFF
--- a/fluig-core/docker/docker-app.yml
+++ b/fluig-core/docker/docker-app.yml
@@ -105,7 +105,7 @@ services:
   comments-application:
     image: platform/fluig-comments:local
     environment:
-      - FLUIG_URL=http://fluig-comments:8080
+      - FLUIG_URL=http://fluig-application:8080
       - FLUIG_HOST_URL_ADDRESS=http://fluig.local:8080
       - FLUIG_DISCOVERY_URL=http://discovery-application:8080
       - FLUIG_SERVICE_BASE_URL=http://comments-application:8080
@@ -137,7 +137,7 @@ services:
   storage-application:
     image: platform/fluig-storage:local
     environment:
-      - FLUIG_URL=http://fluig-storage:8080
+      - FLUIG_URL=http://fluig-application:8080
       - FLUIG_HOST_URL_ADDRESS=http://fluig.local:8080
       - FLUIG_DISCOVERY_URL=http://discovery-application:8080
       - FLUIG_SERVICE_BASE_URL=http://storage-application:8080
@@ -169,7 +169,7 @@ services:
   scheduling-application:
     image: platform/fluig-scheduling:local
     environment:
-      - FLUIG_URL=http://fluig-scheduling:8080
+      - FLUIG_URL=http://fluig-application:8080
       - FLUIG_HOST_URL_ADDRESS=http://fluig.local:8080
       - FLUIG_DISCOVERY_URL=http://discovery-application:8080
       - FLUIG_SERVICE_BASE_URL=http://scheduling-application:8080


### PR DESCRIPTION
Atualmente assim que levanta os serviços de comments, storage e scheduling, os mesmos não conseguem chamar o rest de autenticação por questão da url do fluig não estar mapeada corretamente.